### PR TITLE
feat: add product thumbnails and social bar to product page

### DIFF
--- a/templates/page.merch.liquid
+++ b/templates/page.merch.liquid
@@ -22,6 +22,15 @@
       {% if product.featured_image %}
                  <img class="modal-image" src="{{ product.featured_image | image_url: '600x' }}" data-zoom="{{ product.featured_image | image_url: 'master' }}" alt="{{ product.title }}" />
       {% endif %}
+      {% if product.images.size > 1 %}
+        <div class="modal-thumbnails" style="margin-top: 10px; display: flex; flex-wrap: wrap; gap: 10px; justify-content: center;">
+          {% for image in product.images %}
+            <div style="border: 1px solid #fff; padding: 4px; width: 60px;">
+              <img src="{{ image | image_url: '100x100' }}" data-index="{{ forloop.index0 }}" class="modal-thumb" alt="{{ image.alt | escape }}" style="width: 100%; height: auto; cursor: pointer;" />
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
       <h2 style="margin-top: 20px;">{{ product.title }}</h2>
       <div class="modal-description">{{ product.description | default: '' | newline_to_br }}</div>
       {% form 'product', product, class: 'add-to-cart-form' %}
@@ -100,6 +109,18 @@
       }
       if (prev) prev.addEventListener('click', function (e) { e.stopPropagation(); show('prev'); });
       if (next) next.addEventListener('click', function (e) { e.stopPropagation(); show('next'); });
+      var thumbs = modal.querySelectorAll('.modal-thumb');
+      thumbs.forEach(function (thumb) {
+        thumb.addEventListener('click', function (e) {
+          e.stopPropagation();
+          var idx = parseInt(thumb.dataset.index, 10);
+          modal.dataset.current = idx;
+          if (imgTag) {
+            imgTag.src = images[idx];
+            imgTag.dataset.zoom = images[idx];
+          }
+        });
+      });
     });
  // FIXED: Zoom functionality
             var zoom = document.getElementById('zoom-modal');

--- a/templates/product.liquid
+++ b/templates/product.liquid
@@ -1,20 +1,68 @@
-<div style="max-width: 900px; margin: 160px auto 60px; background: rgba(0,0,0,0.7); padding: 40px; border-radius: 12px; color: #fff; text-align: center;">
+<div style="max-width: 900px; margin: 160px auto 60px; color: #fff; text-align: center;">
   <h1>{{ product.title }}</h1>
-  <div style="margin-top: 20px;">
+  <div style="margin-top: 20px; background: rgba(0,0,0,0.7); padding: 40px; border-radius: 12px;">
     {% if product.featured_image %}
-      <img src="{{ product.featured_image | img_url: '600x' }}" alt="{{ product.title }}" style="max-width: 100%; height: auto;" />
+      <img id="main-product-image" src="{{ product.featured_image | img_url: '600x' }}" alt="{{ product.title }}" style="max-width: 100%; height: auto;" />
     {% endif %}
+    {% if product.images.size > 1 %}
+      <div style="margin-top: 20px; display: flex; flex-wrap: wrap; gap: 10px; justify-content: center;">
+        {% for image in product.images %}
+          <div style="border: 1px solid #fff; padding: 4px; width: 100px;">
+            <img src="{{ image | img_url: '200x' }}" alt="{{ image.alt | escape }}" data-full="{{ image | img_url: '600x' }}" class="product-thumbnail" style="width: 100%; height: auto; cursor: pointer;" />
+          </div>
+        {% endfor %}
+      </div>
+      <script>
+        document.querySelectorAll('.product-thumbnail').forEach(function(thumb) {
+          thumb.addEventListener('click', function() {
+            var fullSrc = this.getAttribute('data-full');
+            var mainImg = document.getElementById('main-product-image');
+            if (mainImg) {
+              mainImg.src = fullSrc;
+            }
+          });
+        });
+      </script>
+    {% endif %}
+    <div style="margin-top: 20px;">
+      {{ product.description | newline_to_br }}
+    </div>
+    {% form 'product', product, class: 'add-to-cart-form' %}
+      <select name="id" style="padding: 8px; border-radius: 4px; margin-right: 8px;">
+        {% for variant in product.variants %}
+          <option value="{{ variant.id }}">{{ variant.title }}</option>
+        {% endfor %}
+      </select>
+      <input type="number" name="quantity" value="1" min="1" style="width: 60px; padding: 8px; border-radius: 4px; margin-right: 8px;" />
+      <button type="submit" style="padding: 10px 20px; border: none; border-radius: 4px; background: #fff; color: #000; font-weight: bold; cursor: pointer;">Add to Cart</button>
+    {% endform %}
   </div>
-  <div style="margin-top: 20px;">
-    {{ product.description | newline_to_br }}
+</div>
+
+<div class="social-bar">
+  <div class="social-bar-inner">
+    <a href="https://www.instagram.com/traktrrecords/?hl=en" target="_blank" title="Instagram" style="display: inline-block;">
+      <svg width="32" height="32" fill="#fff" viewBox="0 0 16 16">
+         <path d="M8 0C5.829 0 5.556.01 4.703.048 3.85.088 3.269.222 2.76.42a3.9 3.9 0 0 0-1.417.923A3.9 3.9 0 0 0 .42 2.76C.222 3.268.087 3.85.048 4.7.01 5.555 0 5.827 0 8.001c0 2.172.01 2.444.048 3.297.04.852.174 1.433.372 1.942.205.526.478.972.923 1.417.444.445.89.719 1.416.923.51.198 1.09.333 1.942.372C5.555 15.99 5.827 16 8 16s2.444-.01 3.298-.048c.851-.04 1.434-.174 1.943-.372a3.9 3.9 0 0 0 1.416-.923c.445-.445.718-.891.923-1.417.197-.509.332-1.09.372-1.942C15.99 10.445 16 10.173 16 8s-.01-2.445-.048-3.299c-.04-.851-.175-1.433-.372-1.941a3.9 3.9 0 0 0-.923-1.417A3.9 3.9 0 0 0 13.24.42c-.51-.198-1.092-.333-1.943-.372C10.443.01 10.172 0 7.998 0zm-.717 1.442h.718c2.136 0 2.389.007 3.232.046.78.035 1.204.166 1.486.275.373.145.64.319.92.599s.453.546.598.92c.11.281.24.705.275 1.485.039.843.047 1.096.047 3.231s-.008 2.389-.047 3.232c-.035.78-.166 1.203-.275 1.485a2.5 2.5 0 0 1-.599.919c-.28.28-.546.453-.92.598-.28.11-.704.24-1.485.276-.843.038-1.096.047-3.232.047s-2.39-.009-3.233-.047c-.78-.036-1.203-.166-1.485-.276a2.5 2.5 0 0 1-.92-.598 2.5 2.5 0 0 1-.6-.92c-.109-.281-.24-.705-.275-1.485-.038-.843-.046-1.096-.046-3.233s.008-2.388.046-3.231c.036-.78.166-1.204.276-1.486.145-.373.319-.64.599-.92s.546-.453.92-.598c.282-.11.705-.24 1.485-.276.738-.034 1.024-.044 2.515-.045zm4.988 1.328a.96.96 0 1 0 0 1.92.96.96 0 0 0 0-1.92m-4.27 1.122a4.109 4.109 0 1 0 0 8.217 4.109 4.109 0 0 0 0-8.217m0 1.441a2.667 2.667 0 1 1 0 5.334 2.667 2.667 0 0 1 0-5.334"/>
+      </svg>
+    </a>
+    <a href="https://www.tiktok.com/@traktrrecords" target="_blank" title="TikTok" style="display: inline-block;">
+      <svg width="42" height="42" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M41.5 17.5c-3.6 0-6.5-2.9-6.5-6.5V6h-6v27.5c0 2.2-1.8 4-4 4s-4-1.8-4-4 1.8-4 4-4c.7 0 1.4.2 2 .5v-6.3c-.7-.1-1.3-.2-2-.2-5.5 0-10 4.5-10 10s4.5 10 10 10 10-4.5 10-10V23.7c1.9 1 4.1 1.8 6.5 1.8v-8z" fill="#fff"/>
+      </svg>
+    </a>
+    <a href="https://soundcloud.com/traktr-records" target="_blank" title="SoundCloud" style="display: inline-block;">
+      <svg width="42" height="42" fill="#fff" viewBox="0 0 24 24">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M10.08 7.34372C12.8728 3.12774 19.2674 5.19508 19.68 10.0937C25 9.50012 25.5105 17.5 20.4 17.5H10.08V7.34372ZM7.20002 7.59372C7.48877 7.54294 7.82439 7.49997 8.16002 7.49997V17.5H7.20002V7.59372ZM8.64002 7.49997V17.5H9.60002V7.74997C9.31127 7.65036 8.97565 7.55075 8.64002 7.49997ZM5.76002 8.24997C6.04877 8.05075 6.38439 7.90036 6.72002 7.74997V17.5H5.76002V8.24997ZM5.28002 8.65622C4.89564 9.00583 4.56002 9.45309 4.32002 9.95309V17.5H5.28002V8.65622ZM2.88002 10.5468C3.16267 10.4461 3.56317 10.4495 3.84002 10.5468V17.5C3.53701 17.5 3.16994 17.5551 2.88002 17.4531V10.5468ZM2.40002 10.6562C2.06439 10.7558 1.72877 10.9062 1.44002 11.1562V16.8437C1.72877 17.0429 2.06439 17.2441 2.40002 17.3437V10.6562ZM0.96002 16.4531V11.5468C-0.291035 12.9604 -0.291035 15.0395 0.96002 16.4531Z"/>
+      </svg>
+    </a>
+    <a href="https://open.spotify.com/playlist/04khi1qRJaoR5RXeudYV5w?si=vyCuXZkMQXS8QAF8lpUEHg" target="_blank" title="Spotify" style="display: inline-block;">
+      <svg width="32" height="32" fill="#fff" viewBox="0 0 24 24"><path d="M12 0C5.371 0 0 5.371 0 12c0 6.627 5.371 12 12 12s12-5.373 12-12c0-6.629-5.371-12-12-12zm5.297 17.438c-.221.363-.691.479-1.055.258-2.891-1.771-6.543-2.168-10.822-1.18-.414.096-.832-.154-.928-.568-.096-.414.154-.832.568-.928 4.646-1.07 8.668-.627 11.857 1.289.363.221.479.691.258 1.055zm1.518-2.625c-.277.449-.857.592-1.307.316-3.309-2.039-8.354-2.633-12.26-1.434-.516.156-1.064-.133-1.221-.648-.156-.516.133-1.064.648-1.221 4.377-1.326 9.857-.68 13.637 1.602.449.277.592.857.316 1.307zm.143-2.684c-3.979-2.367-10.563-2.582-14.357-1.406-.617.188-1.273-.148-1.461-.766-.188-.617.148-1.273.766-1.461 4.229-1.289 11.438-1.045 15.922 1.602.566.338.748 1.07.41 1.637-.338.566-1.07.748-1.637.41zm.002 0"/></svg>
+    </a>
+    <a href="https://www.beatport.com/label/traktr-records/131040" title="Listen" style="display: inline-block; width: 32px; height: 32px; opacity: 0.8; transition: opacity 0.3s; color: #fff; text-decoration: none; font-size: 24px; text-align: center; line-height: 32px;" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.8'">
+      <svg width="32" height="32" fill="#fff" viewBox="0 0 24 24">
+        <path d="M14.668 24c-3.857 0-6.935-3.039-6.935-6.974a6.98 6.98 0 0 1 1.812-4.714l-4.714 4.714-2.474-2.474 5.319-5.26c.72-.72 1.09-1.656 1.09-2.688V0h3.487v6.604c0 2.026-.72 3.74-2.123 5.143l-.156.156a6.945 6.945 0 0 1 4.694-1.812c3.955 0 6.975 3.136 6.975 6.935A6.943 6.943 0 0 1 14.668 24zm0-10.714c-2.123 0-3.779 1.753-3.779 3.74 0 2.045 1.675 3.78 3.78 3.78a3.804 3.804 0 0 0 3.818-3.78c0-2.065-1.715-3.74-3.819-3.74z"/>
+      </svg>
+    </a>
   </div>
-  {% form 'product', product, class: 'add-to-cart-form' %}
-    <select name="id" style="padding: 8px; border-radius: 4px; margin-right: 8px;">
-      {% for variant in product.variants %}
-        <option value="{{ variant.id }}">{{ variant.title }}</option>
-      {% endfor %}
-    </select>
-    <input type="number" name="quantity" value="1" min="1" style="width: 60px; padding: 8px; border-radius: 4px; margin-right: 8px;" />
-    <button type="submit" style="padding: 10px 20px; border: none; border-radius: 4px; background: #fff; color: #000; font-weight: bold; cursor: pointer;">Add to Cart</button>
-  {% endform %}
 </div>


### PR DESCRIPTION
## Summary
- wrap product details in a dark box with thumbnail gallery beneath main image
- add a social media bar to the product page matching the release page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a7ba35b908327b4d90b09af6d9a1a